### PR TITLE
Set `input` to `password` when receiving password prompt

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -49,6 +49,18 @@
 
         // Handle messages from the server
         socket.onmessage = (event) => {
+            /**
+             * If input is a password, change input type to password.  
+             * This hides it using asterisks.
+             * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password
+             * 
+             * If more things should be hidden, consider adding a flag instead of using the message string itself.
+            **/
+            if(event.data == "Your \u001b[1;32mpassword\u001b[0m:\n") {
+                input.type = "password";
+            } else {
+                input.type = "text";
+            }
             appendAnsiMessage(event.data);
         };
 


### PR DESCRIPTION
Change the input type to `password`when receiving a password prompt, ensuring that the input is obscured with asterisks. This improves security during password entry against attacks like shoulder surfing.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password

THIS WILL STOP WORKING IF PASSWORD PROMPT CHANGES FROM `Your \u001b[1;32mpassword\u001b[0m:\n"`

Consider adding flags to message or another way to update expected responses between server and client to resolve this potential issue.